### PR TITLE
Decode URL to allow spaces and other encoded chars

### DIFF
--- a/adaptive-images.php
+++ b/adaptive-images.php
@@ -27,7 +27,7 @@ $mobile_first  = TRUE; // If there's no cookie sends the mobile version (if FALS
 /* get all of the required data from the HTTP request */
 $document_root  = $_SERVER['DOCUMENT_ROOT'];
 $requested_uri  = parse_url(urldecode($_SERVER['REQUEST_URI']), PHP_URL_PATH);
-$requested_file = basename(urldecode($requested_uri));
+$requested_file = basename($requested_uri);
 $source_file    = $document_root.$requested_uri;
 $resolution     = FALSE;
 


### PR DESCRIPTION
I'm using adaptive images with a CMS and clients love uploading images with spaces in the filenames. I suppose I could force no special chars or change the filename on save, but I'm not sure about other characters that might show up so this seemed the more conclusive fix.
