### PR TITLE
in is_mobile(); strpos would return false if the string is not found, but would return 0 if the string is in the first character

### DIFF
--- a/adaptive-images.php
+++ b/adaptive-images.php
@@ -34,15 +34,11 @@ $resolution     = FALSE;
    NOTE: only used in the event a cookie isn't available. */
 function is_mobile() {
   $userAgent = strtolower($_SERVER['HTTP_USER_AGENT']);
-  return strpos($userAgent, 'mobile');
+  return (false !== strpos($userAgent, 'mobile'));
 }
 
 /* Does the UA string indicate this is a mobile? */
-if(!is_mobile()){
-  $is_mobile = FALSE;
-} else {
-  $is_mobile = TRUE;
-}
+$is_mobile = is_mobile();
 
 // does the $cache_path directory exist already?
 if (!is_dir("$document_root/$cache_path")) { // no


### PR DESCRIPTION
0 still means false, so i changed it to a typed comparation to false (!==, notice the extra equal sign).

in that case, you don't have to bother with another if to assign $is_mobile, so i changed it to a direct assignment
