### PR TITLE
Added availability to skip the adaption process

### DIFF
--- a/adaptive-images.php
+++ b/adaptive-images.php
@@ -29,7 +29,7 @@ $requested_uri  = parse_url(urldecode($_SERVER['REQUEST_URI']), PHP_URL_PATH);
 $requested_file = basename($requested_uri);
 $source_file    = $document_root.$requested_uri;
 $resolution     = FALSE;
-$transmitOriginalImage = ((isset($_GET['skipAdaptive']) && $_GET['skipAdaptive']=1) ? true : false);
+$transmitOriginalImage = ((isset($_GET['skipAdaptive']) && $_GET['skipAdaptive']==1) ? true : false);
 
 if($transmitOriginalImage) {
    sendImage($source_file, $browser_cache); // Exit implicitly


### PR DESCRIPTION
L32-L36: If a GET-Parameter ('skipAdaptive') is transmitted in the HTTP-Request with value==1, then the rest of the script is ignored and the original image is sent to the browser without any adaption. (Resize, compression, etc.)

Example URL: www.yourserver.org/hqimage.jpg?skipAdaptive=1

---

I need this feature for press downloads: Regardless of the screen resolution, the visitors should be able to view/download some certain images in full quality (eg. print versions, etc.)

...may be useful for someone else too...
