### PR TITLE
Code cleanup and redundancy elimination

### DIFF
--- a/adaptive-images.php
+++ b/adaptive-images.php
@@ -235,7 +235,7 @@ if (isset($_COOKIE['resolution'])) {
     $client_width  = (int) $cookie_data[0]; // the base resolution (CSS pixels)
     $total_width   = $client_width;
     $pixel_density = 1; // set a default, used for non-retina style JS snippet
-    if (@$cookie_data[1]) { // the device's pixel density factor (physical pixels per CSS pixel)
+    if (isset($cookie_data[1]) && $cookie_data[1]) { // the device's pixel density factor (physical pixels per CSS pixel)
       $pixel_density = $cookie_data[1];
     }
 

--- a/adaptive-images.php
+++ b/adaptive-images.php
@@ -180,22 +180,22 @@ function generateImage($source_file, $cache_file, $resolution) {
   }
 
   // save the new file in the appropriate path, and send a version to the browser
-  $gotSaved = false;
+  $wasSaved = false;
 
   switch ($imagemeta[2]) {
     case IMAGETYPE_PNG:
-      $gotSaved = ImagePng($dst, $cache_file);
+      $wasSaved = ImagePng($dst, $cache_file);
     break;
     case IMAGETYPE_GIF:
-      $gotSaved = ImageGif($dst, $cache_file);
+      $wasSaved = ImageGif($dst, $cache_file);
     break;
     default:
-      $gotSaved = ImageJpeg($dst, $cache_file, $jpg_quality);
+      $wasSaved = ImageJpeg($dst, $cache_file, $jpg_quality);
     break;
   }
   ImageDestroy($dst);
 
-  if (!$gotSaved && !file_exists($cache_file)) {
+  if (!$wasSaved && !file_exists($cache_file)) {
     sendErrorImage("Failed to create image: $cache_file");
   }
 
@@ -277,10 +277,8 @@ if (!$resolution) {
   $resolution = $is_mobile ? min($resolutions) : max($resolutions);
 }
 
-/* if the requested URL starts with a slash, remove the slash */
-if (substr($requested_uri, 0,1) == "/") {
-  $requested_uri = substr($requested_uri, 1);
-}
+/* trim any potential leading slashes */
+$requested_uri = ltrim($requested_uri, "/");
 
 /* whew might the cache file be? */
 $cache_file = $document_root."/$cache_path/$resolution/".$requested_uri;

--- a/adaptive-images.php
+++ b/adaptive-images.php
@@ -50,8 +50,8 @@ if (!is_dir("$document_root/$cache_path")) { // no
   }
 }
 
-if (!is_writable($cache_dir)) {
-    sendErrorImage("The cache directory is not writable: $cache_dir");
+if (!is_writable("$document_root/$cache_path")) {
+    sendErrorImage("The cache directory is not writable: $document_root/$cache_path");
 }
 
 /* helper function: Send headers and returns an image. */

--- a/adaptive-images.php
+++ b/adaptive-images.php
@@ -77,7 +77,7 @@ function sendErrorImage($message) {
   $requested_file = basename($requested_uri);
   $source_file    = $document_root.$requested_uri;
 
-  if(!is_mobile()){
+  if (!is_mobile()){
     $is_mobile = "FALSE";
   } else {
     $is_mobile = "TRUE";
@@ -169,7 +169,7 @@ function generateImage($source_file, $cache_file, $resolution) {
 
   // sharpen the image?
   // NOTE: requires PHP compiled with the bundled version of GD (see http://php.net/manual/en/function.imageconvolution.php)
-  if($sharpen == TRUE && function_exists('imageconvolution')) {
+  if ($sharpen == TRUE && function_exists('imageconvolution')) {
     $intSharpness = findSharp($width, $new_width);
     $arrMatrix = array(
       array(-1, -2, -1),
@@ -236,11 +236,11 @@ if (isset($_COOKIE['resolution'])) {
     $resolution = $resolutions[0]; // by default use the largest supported break-point
 
     // if pixel density is not 1, then we need to be smart about adapting and fitting into the defined breakpoints
-    if($pixel_density != 1) {
+    if ($pixel_density != 1) {
       $total_width = $client_width * $pixel_density; // required physical pixel width of the image
 
       // the required image width is bigger than any existing value in $resolutions
-      if($total_width > $resolutions[0]){
+      if ($total_width > $resolutions[0]){
         // firstly, fit the CSS size into a break point ignoring the multiplier
         foreach ($resolutions as $break_point) { // filter down
           if ($total_width <= $break_point) {
@@ -276,7 +276,7 @@ if (!$resolution) {
 }
 
 /* if the requested URL starts with a slash, remove the slash */
-if(substr($requested_uri, 0,1) == "/") {
+if (substr($requested_uri, 0,1) == "/") {
   $requested_uri = substr($requested_uri, 1);
 }
 

--- a/adaptive-images.php
+++ b/adaptive-images.php
@@ -133,8 +133,6 @@ function refreshCache($source_file, $cache_file, $resolution) {
 function generateImage($source_file, $cache_file, $resolution) {
   global $sharpen, $jpg_quality;
 
-  $extension = strtolower(pathinfo($source_file, PATHINFO_EXTENSION));
-
   // Check the image dimensions
   $imagemeta    = GetImageSize($source_file);
 

--- a/adaptive-images.php
+++ b/adaptive-images.php
@@ -213,7 +213,7 @@ function generateImage($source_file, $cache_file, $resolution) {
 
 // check if the file exists at all
 if (!file_exists($source_file)) {
-  header("Status: 404 Not Found");
+  header("Not Found", true, 404);
   exit();
 }
 

--- a/adaptive-images.php
+++ b/adaptive-images.php
@@ -165,7 +165,8 @@ function generateImage($source_file, $cache_file, $resolution) {
   if ($imagemeta[2] === IMAGETYPE_JPEG) {
     ImageInterlace($dst, true); // Enable interlancing (progressive JPG, smaller size file)
   }
-  elseif ($imagemeta[2] === IMAGETYPE_PNG) {
+  elseif ($imagemeta[2] === IMAGETYPE_PNG && $imagemeta["bits"] > 1) {
+    // save alpha for png's that have the alpha channel
     imagealphablending($dst, false);
     imagesavealpha($dst,true);
     $transparent = imagecolorallocatealpha($dst, 255, 255, 255, 127);

--- a/adaptive-images.php
+++ b/adaptive-images.php
@@ -180,6 +180,8 @@ function generateImage($source_file, $cache_file, $resolution) {
   }
 
   // save the new file in the appropriate path, and send a version to the browser
+  $gotSaved = false;
+
   switch ($imagemeta[2]) {
     case IMAGETYPE_PNG:
       $gotSaved = ImagePng($dst, $cache_file);

--- a/adaptive-images.php
+++ b/adaptive-images.php
@@ -50,6 +50,10 @@ if (!is_dir("$document_root/$cache_path")) { // no
   }
 }
 
+if (!is_writable($cache_dir)) {
+    sendErrorImage("The cache directory is not writable: $cache_dir");
+}
+
 /* helper function: Send headers and returns an image. */
 function sendImage($filename, $browser_cache) {
   $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
@@ -180,11 +184,6 @@ function generateImage($source_file, $cache_file, $resolution) {
       array(-1, -2, -1)
     );
     imageconvolution($dst, $arrMatrix, $intSharpness, 0);
-  }
-
-  if (!is_writable($cache_dir)) {
-    sendErrorImage("The cache directory is not writable: $cache_dir");
-    ImageDestroy($dst);
   }
 
   // save the new file in the appropriate path, and send a version to the browser

--- a/adaptive-images.php
+++ b/adaptive-images.php
@@ -182,22 +182,9 @@ function generateImage($source_file, $cache_file, $resolution) {
     imageconvolution($dst, $arrMatrix, $intSharpness, 0);
   }
 
-  $cache_dir = dirname($cache_file);
-
-  // does the directory exist already?
-  if (!is_dir($cache_dir)) {
-    if (!mkdir($cache_dir, 0755, true)) {
-      // check again if it really doesn't exist to protect against race conditions
-      if (!is_dir($cache_dir)) {
-        // uh-oh, failed to make that directory
-        ImageDestroy($dst);
-        sendErrorImage("Failed to create cache directory: $cache_dir");
-      }
-    }
-  }
-
   if (!is_writable($cache_dir)) {
     sendErrorImage("The cache directory is not writable: $cache_dir");
+    ImageDestroy($dst);
   }
 
   // save the new file in the appropriate path, and send a version to the browser

--- a/adaptive-images.php
+++ b/adaptive-images.php
@@ -137,6 +137,12 @@ function generateImage($source_file, $cache_file, $resolution) {
 
   // Check the image dimensions
   $imagemeta    = GetImageSize($source_file);
+
+  if ($imagemeta === false) {
+    // Either an unsupported image type or not an image
+    sendErrorImage("Failed to read source image: $source_file");
+  }
+
   $width        = $imagemeta[0];
   $height       = $imagemeta[1];
 
@@ -153,6 +159,10 @@ function generateImage($source_file, $cache_file, $resolution) {
 
   $srcimageinfo = GetImageSize($source_file);
   $src = ImageCreateFromString(file_get_contents($source_file));
+
+  if ($src === false) {
+    sendErrorImage("Failed to read source image: $source_file");
+  }
 
   if ($imagemeta[2] === IMAGETYPE_JPEG) {
     ImageInterlace($dst, true); // Enable interlancing (progressive JPG, smaller size file)

--- a/adaptive-images.php
+++ b/adaptive-images.php
@@ -30,7 +30,7 @@ $requested_file = basename($requested_uri);
 $source_file    = $document_root.$requested_uri;
 $resolution     = FALSE;
 
-/* Mobile detection 
+/* Mobile detection
    NOTE: only used in the event a cookie isn't available. */
 function is_mobile() {
   $userAgent = strtolower($_SERVER['HTTP_USER_AGENT']);
@@ -38,11 +38,7 @@ function is_mobile() {
 }
 
 /* Does the UA string indicate this is a mobile? */
-if(!is_mobile()){
-  $is_mobile = FALSE;
-} else {
-  $is_mobile = TRUE;
-}
+$is_mobile = is_mobile();
 
 // does the $cache_path directory exist already?
 if (!is_dir("$document_root/$cache_path")) { // no
@@ -170,7 +166,7 @@ function generateImage($source_file, $cache_file, $resolution) {
     $transparent = imagecolorallocatealpha($dst, 255, 255, 255, 127);
     imagefilledrectangle($dst, 0, 0, $new_width, $new_height, $transparent);
   }
-  
+
   ImageCopyResampled($dst, $src, 0, 0, 0, 0, $new_width, $new_height, $width, $height); // do the resize in memory
   ImageDestroy($src);
 
@@ -189,7 +185,7 @@ function generateImage($source_file, $cache_file, $resolution) {
   $cache_dir = dirname($cache_file);
 
   // does the directory exist already?
-  if (!is_dir($cache_dir)) { 
+  if (!is_dir($cache_dir)) {
     if (!mkdir($cache_dir, 0755, true)) {
       // check again if it really doesn't exist to protect against race conditions
       if (!is_dir($cache_dir)) {

--- a/adaptive-images.php
+++ b/adaptive-images.php
@@ -281,7 +281,7 @@ if (!$resolution) {
 $requested_uri = ltrim($requested_uri, "/");
 
 /* whew might the cache file be? */
-$cache_file = $document_root."/$cache_path/$resolution/".$requested_uri;
+$cache_file = $document_root."/$cache_path/$resolution.".$requested_uri;
 
 /* Use the resolution value as a path variable and check to see if an image of the same name exists at that path */
 if (file_exists($cache_file)) { // it exists cached at that size


### PR DESCRIPTION
Removed some redundant statements, fixed some coding style inconsistencies. Also significantly changed logic for some parts, which may or not be acceptable in your mind.
- Dropped multi-tier cache dir structure (it's machine read only, it doesn't need to be clean)
- No longer relies on file extension to exist or be correct (in generateImage)

I tried to keep commits as small as possible, which is why there are so many. I can squash them if you prefer fewer.
