### PR TITLE
Convert color profiles in JPEG into sRGB

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+  ENHANCEMENT
+    * The program "jpegicc" can be used to automatically convert all JPEG-images with
+      embedded color profiles into sRGB.
+
 version 1.5.2 (2012/04/16) ------------------------------------------------------------
 
   BUG FIX


### PR DESCRIPTION
I encountered a problem with Adaptive Images when using it for Jpeg files that have an embedded color profile. The color profile is lost, as this seems to be not yet supported by the GD library, changing the displayed colors. The problem can be seen here: http://adaptive.hoessl.eu/ ; the upper image is the original, the lower one is converted image; the bright red color has changed into something rather brownish.
The only solution I found to this problem was to use an external programm to convert the images into sRGB; the proposed patch uses the program "jpegicc".
