### PR TITLE
Update is_mobile() function

### DIFF
--- a/adaptive-images.php
+++ b/adaptive-images.php
@@ -34,15 +34,11 @@ $resolution     = FALSE;
    NOTE: only used in the event a cookie isn't available. */
 function is_mobile() {
   $userAgent = strtolower($_SERVER['HTTP_USER_AGENT']);
-  return strpos($userAgent, 'mobile');
+  return !!strpos($userAgent, 'mobile');
 }
 
 /* Does the UA string indicate this is a mobile? */
-if(!is_mobile()){
-  $is_mobile = FALSE;
-} else {
-  $is_mobile = TRUE;
-}
+$is_mobile = is_mobile();
 
 // does the $cache_path directory exist already?
 if (!is_dir("$document_root/$cache_path")) { // no
@@ -76,12 +72,6 @@ function sendErrorImage($message) {
   $requested_uri  = parse_url(urldecode($_SERVER['REQUEST_URI']), PHP_URL_PATH);
   $requested_file = basename($requested_uri);
   $source_file    = $document_root.$requested_uri;
-
-  if(!is_mobile()){
-    $is_mobile = "FALSE";
-  } else {
-    $is_mobile = "TRUE";
-  }
 
   $im            = ImageCreateTrueColor(800, 300);
   $text_color    = ImageColorAllocate($im, 233, 14, 91);


### PR DESCRIPTION
I have changed the `is_mobile()` function so that it returns a boolean.

```
function is_mobile() {
  $userAgent = strtolower($_SERVER['HTTP_USER_AGENT']);
  return !!strpos($userAgent, 'mobile');
}
```

This renders this if/else block unnecessary:

```
if(!is_mobile()){
  $is_mobile = "FALSE";
} else {
  $is_mobile = "TRUE";
}
```

I have removed this and replaced it with `$is_mobile = is_mobile();`.

I have also removed the same if else block from within the `sendErrorImage()` function, but I have **not** replaced it as the variable was unused within its scope.

It's worth pointing out that the `$is_mobile` variable is only used once in the entire script. It might be a better idea to remove the function all together, and just use `$is_mobile = !!strpos(strtolower($_SERVER['HTTP_USER_AGENT']);`. I haven't made this change as there may be need for this helper function in the future.
