### PR TITLE
prevent artefacts in white areas

### DIFF
--- a/adaptive-images.php
+++ b/adaptive-images.php
@@ -171,7 +171,10 @@ function generateImage($source_file, $cache_file, $resolution) {
     imagefilledrectangle($dst, 0, 0, $new_width, $new_height, $transparent);
   }
   
+  // invert the image to prevent atrifacts on white areas
+  imagefilter($src, IMG_FILTER_NEGATE);
   ImageCopyResampled($dst, $src, 0, 0, 0, 0, $new_width, $new_height, $width, $height); // do the resize in memory
+  imagefilter($dst, IMG_FILTER_NEGATE);
   ImageDestroy($src);
 
   // sharpen the image?


### PR DESCRIPTION
A similar issue described here: http://stackoverflow.com/questions/23993901/imagecopyresampled-introduces-artifacts-in-transparent-png

Although this is happening to me too, if i use a jpeg with large white areas.
The result does contain grey atrifacts rgb(255,255,254), where only white rgb(255,255,255) should be.

Inverting the image before resizing and inverting it back to normal does fix the issue for me.

